### PR TITLE
Switch all uris to https

### DIFF
--- a/routes.coffee
+++ b/routes.coffee
@@ -1,9 +1,9 @@
 request = require 'request'
 
-SITE_HOME = "http://darvin.github.com/mimetype-icon/"
-BASE_ICONS_URL = "http://darvin.github.com/mimetype-icon/Icons/Icons/"
+SITE_HOME = "https://darvin.github.com/mimetype-icon/"
+BASE_ICONS_URL = "https://darvin.github.com/mimetype-icon/Icons/Icons/"
 ICONS_MANIFEST_URL = \
-  "http://darvin.github.com/mimetype-icon/Icons/FileTypeIcons.json"
+  "https://darvin.github.com/mimetype-icon/Icons/FileTypeIcons.json"
 DIRECTORY_ICON_NAMES = [
   "directory",
   "dir",


### PR DESCRIPTION
You're currently redirecting via http which means the icons can't be used on https sites without losing the [secure] badge – even though the final uri ends up being https (github pages now all being on https)